### PR TITLE
Potential fix for code scanning alert no. 2: DOM text reinterpreted as HTML

### DIFF
--- a/site/main.js
+++ b/site/main.js
@@ -99,14 +99,35 @@ function handleFileUpload(event) {
 
   const info = document.createElement('div');
   info.className = 'file-info';
-  info.innerHTML = `
-    <div style="display:flex;align-items:center;margin-bottom:10px">
-      <div style="margin-right:15px">${icon}</div>
-      <div>
-        <div style="font-weight:bold;font-size:16px">${file.name}</div>
-        <div style="color:#a3aab4;font-size:14px">${(file.size / 1024).toFixed(2)} KB</div>
-      </div>
-    </div>`;
+  // Build file info DOM safely
+  const infoRow = document.createElement('div');
+  infoRow.style.display = 'flex';
+  infoRow.style.alignItems = 'center';
+  infoRow.style.marginBottom = '10px';
+
+  const iconDiv = document.createElement('div');
+  iconDiv.style.marginRight = '15px';
+  iconDiv.innerHTML = icon; // icon is static SVG, safe to use as HTML
+
+  const detailsDiv = document.createElement('div');
+
+  const nameDiv = document.createElement('div');
+  nameDiv.style.fontWeight = 'bold';
+  nameDiv.style.fontSize = '16px';
+  nameDiv.textContent = file.name;
+
+  const sizeDiv = document.createElement('div');
+  sizeDiv.style.color = '#a3aab4';
+  sizeDiv.style.fontSize = '14px';
+  sizeDiv.textContent = `${(file.size / 1024).toFixed(2)} KB`;
+
+  detailsDiv.appendChild(nameDiv);
+  detailsDiv.appendChild(sizeDiv);
+
+  infoRow.appendChild(iconDiv);
+  infoRow.appendChild(detailsDiv);
+
+  info.appendChild(infoRow);
 
   const progress = document.createElement('progress');
   progress.max = 1;


### PR DESCRIPTION
Potential fix for [https://github.com/nboyers/NotGPT.me/security/code-scanning/2](https://github.com/nboyers/NotGPT.me/security/code-scanning/2)

To fix the problem, we must ensure that any user-controlled data (such as `file.name`) is properly escaped before being inserted into the DOM as HTML. The best way to do this is to avoid using `.innerHTML` for user data, and instead use `.textContent` or create DOM nodes and set their text content. For the SVG icon, which is safe and static, we can insert it as HTML, but for the file name and size, we should use `.textContent` to prevent XSS. Specifically, in the block that creates the file info display (lines 100–109), we should:

- Create the structure using DOM methods (e.g., `createElement`, `appendChild`).
- Set the file name and size using `.textContent` instead of interpolating them into an HTML string.
- Only use `.innerHTML` for the static SVG icon.

This change should be made in the `handleFileUpload` function in `site/main.js`, specifically lines 100–109.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
